### PR TITLE
Work with PP services with subdirectory URLs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -23,3 +23,6 @@ All changes will be saved instantly, no need to save separately.
 
 I will improve the UI and the documentation in the coming days, if there are and issues or questions fell free to open an issue 
 
+## Limiting the Site Access
+
+In case the augmented buttons for manipulating face markers appear in websites other than your PhotoPrism service, you might want to limit the Site access permission to your PhotoPrism server domain. To locate the permission settings, open extensions (`chrome://extensions`) > PhotoPrism Face Marker "Details" > Site Access.

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
   "host_permissions": ["http:\/\/*\/*", "https:\/\/*\/*"],
   "content_scripts": [
     {
-      "matches": ["*://*/browse*", "*://*/library*"],
+      "matches": ["*://*/*browse*", "*://*/*library*"],
       "js": ["contentScript.js"],
       "world": "MAIN"
     }


### PR DESCRIPTION
Work with PP services with subdirectory URLs
In case the PhotoPrism is served from subdirectory (e.g.
`https://domain.com/photoprism`) a bit broader match rule is
required.

In theory, the more allowing rule might execute the script in URLs
other than PhotoPrism. However, in practice the script itself creates
the buttons only if correctly named elements are found in the page.

This drawback can be effectively ruled out by making the extension
permissions tighter than the default. This is now documented in the
README.md.